### PR TITLE
Streamlined visualization

### DIFF
--- a/example/visualize.py
+++ b/example/visualize.py
@@ -31,5 +31,4 @@ if __name__ == '__main__':
     visualize(predictor,
               query_df,
               subset=subset,
-              mode=mode,
-              rolling=rolling)
+              mode=mode)

--- a/mindsdb_forecast_visualizer/core/dispatch.py
+++ b/mindsdb_forecast_visualizer/core/dispatch.py
@@ -1,9 +1,9 @@
 from mindsdb_forecast_visualizer.core.forecaster import forecast
 
 
-def visualize(mdb_predictor, df, subset=None, mode='Native', rolling=1):
+def visualize(mdb_predictor, df, subset=None, mode='Native'):
     if mode == 'Native':
-        forecast(mdb_predictor, df, rolling=rolling, subset=subset)
+        forecast(mdb_predictor, df, subset=subset)
 
     if mode == 'SDK':
         print('SDK mode currently not supported.')  # TODO mode SDK


### PR DESCRIPTION
## Why

To have a consistent visualization across `t+n` forecasters, for any `n`. Fixes #2.

## How

Removed `rolling` parameter, simplified `core/forecaster.py` logic quite a lot.